### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -4,5 +4,5 @@ if type -q direnv
     eval (direnv export fish)
   end
 else
-  echo "Install direnv first! Check http://direnv.net" ^&1
+  echo "Install direnv first! Check http://direnv.net" 2>&1
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618