### PR TITLE
Fixes direnv on new tab

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,4 +1,5 @@
 if type -q direnv
+  eval (direnv export fish)
   function __direnv_export_eval --on-variable PWD
     status --is-command-substitution; and return
     eval (direnv export fish)


### PR DESCRIPTION
When creating a new tab, direnv is not parsed. This fixes that. I didn't create the original code change. 



